### PR TITLE
chore: rename knork->spife, version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.nyc_output

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.pkg.github.com/npm

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 if (process.argv[3] === '--help') {
   console.log(`
-knork-dev-logger [file]
+spife-dev-logger [file]
 
 Pretty print a NDJSON log. If \`file\` is omitted, will read on stdin.
   `.trim())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@npm/knork-dev-logger",
+  "name": "@npm/spife-dev-logger",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@npm/spife-dev-logger",
+  "name": "@npm/knork-dev-logger",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@npm/knork-dev-logger",
-  "version": "1.0.0",
+  "name": "@npm/spife-dev-logger",
+  "version": "1.1.0",
   "main": "dev-logger.js",
   "bin": {
-    "knork-dev-logger": "./cli.js"
+    "spife-dev-logger": "./cli.js"
   },
   "scripts": {
     "test": "TZ=UTC tap --100 test.js",
@@ -28,11 +28,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/npm/knork-dev-logger.git"
+    "url": "git+https://github.com/npm/spife-dev-logger.git"
   },
   "bugs": {
-    "url": "https://github.com/npm/knork-dev-logger/issues"
+    "url": "https://github.com/npm/spife-dev-logger/issues"
   },
-  "homepage": "https://github.com/npm/knork-dev-logger#readme",
+  "homepage": "https://github.com/npm/spife-dev-logger#readme",
   "description": ""
 }

--- a/test.js
+++ b/test.js
@@ -192,7 +192,7 @@ test('passes unparsable lines through', async assert => {
   assert.equal(result, 'hello world\n00:00:00 200     10ms    GET /foo (id: 📖 )\n')
 })
 
-test('non-knork request ids are passed through', async assert => {
+test('non-spife request ids are passed through', async assert => {
   id.id = 0
   const logger = createLogger()
   const currentId = id()
@@ -323,7 +323,7 @@ test('grouped (handles errors)', async assert => {
       time: date
     })).pipe(logger)
   )
-  assert.equal(result, '00:00:00 200     10ms    GET /foo (id: 📖 )\n    +50s ERR womp Error\n                  at Test.test (/Users/chris/projects/npm/knork-dev-logger/test.js:N:N)\n')
+  assert.match(result, '00:00:00 200     10ms    GET /foo (id: 📖 )\n    +50s ERR womp Error\n                  at Test.test')
 })
 
 test('grouped (handles errors w/no stack)', async assert => {


### PR DESCRIPTION
Previously we had issues publishing `spife-dev-logger` to GH packages (presumably) because the package.json specifies it as `knork-dev-logger`. 

- Rename knork -> spife.
- Fix brittle unit test (was expecting a path on a specific developer's machine). 
- Version bump
